### PR TITLE
Require all contact form fields before submitting

### DIFF
--- a/.vitepress/tests/components/HomeContact.test.ts
+++ b/.vitepress/tests/components/HomeContact.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { shallowMount } from "@vue/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, shallowMount } from "@vue/test-utils";
 
 vi.mock("@data/resume", () => ({
   default: {},
@@ -12,5 +12,130 @@ describe("HomeContact", () => {
   it("renders correctly", () => {
     const wrapper = shallowMount(HomeContact);
     expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  describe("required field validation", () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal("fetch", fetchMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    async function fill(
+      wrapper: ReturnType<typeof mount>,
+      { name = "", email = "", message = "" } = {},
+    ) {
+      await wrapper.find('input[name="name"]').setValue(name);
+      await wrapper.find('input[name="email"]').setValue(email);
+      await wrapper.find('textarea[name="message"]').setValue(message);
+    }
+
+    async function submit(wrapper: ReturnType<typeof mount>) {
+      await wrapper.find("form").trigger("submit.prevent");
+      // allow the (potential) async fetch handler to settle
+      await Promise.resolve();
+      await wrapper.vm.$nextTick();
+    }
+
+    it("does not submit when all fields are empty", async () => {
+      const wrapper = mount(HomeContact);
+      await submit(wrapper);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(wrapper.find("#contactStatus").text()).toBe(
+        "Please fill in all fields before sending.",
+      );
+      expect(wrapper.find("#contactStatus").classes()).toContain(
+        "text-red-500",
+      );
+    });
+
+    it("does not submit when the name is missing", async () => {
+      const wrapper = mount(HomeContact);
+      await fill(wrapper, { email: "a@b.com", message: "Hello there" });
+      await submit(wrapper);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(wrapper.find("#contactStatus").text()).toBe(
+        "Please fill in all fields before sending.",
+      );
+    });
+
+    it("does not submit when the email is missing", async () => {
+      const wrapper = mount(HomeContact);
+      await fill(wrapper, { name: "Dan", message: "Hello there" });
+      await submit(wrapper);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(wrapper.find("#contactStatus").text()).toBe(
+        "Please fill in all fields before sending.",
+      );
+    });
+
+    it("does not submit when the message is missing", async () => {
+      const wrapper = mount(HomeContact);
+      await fill(wrapper, { name: "Dan", email: "a@b.com" });
+      await submit(wrapper);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(wrapper.find("#contactStatus").text()).toBe(
+        "Please fill in all fields before sending.",
+      );
+    });
+
+    it("does not submit when fields contain only whitespace", async () => {
+      const wrapper = mount(HomeContact);
+      await fill(wrapper, { name: "   ", email: "  ", message: "   " });
+      await submit(wrapper);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(wrapper.find("#contactStatus").text()).toBe(
+        "Please fill in all fields before sending.",
+      );
+    });
+
+    it("submits when all fields are filled in", async () => {
+      const wrapper = mount(HomeContact);
+      await fill(wrapper, {
+        name: "Dan",
+        email: "a@b.com",
+        message: "Hello there",
+      });
+      await submit(wrapper);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("/");
+      const params = new URLSearchParams(options.body as string);
+      expect(params.get("name")).toBe("Dan");
+      expect(params.get("email")).toBe("a@b.com");
+      expect(params.get("message")).toBe("Hello there");
+      expect(wrapper.find("#contactStatus").text()).toBe(
+        "Message sent — I'll be in touch soon.",
+      );
+    });
+
+    it("trims surrounding whitespace from submitted values", async () => {
+      const wrapper = mount(HomeContact);
+      await fill(wrapper, {
+        name: "  Dan  ",
+        email: "  a@b.com  ",
+        message: "  Hello there  ",
+      });
+      await submit(wrapper);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const params = new URLSearchParams(
+        fetchMock.mock.calls[0][1].body as string,
+      );
+      expect(params.get("name")).toBe("Dan");
+      expect(params.get("email")).toBe("a@b.com");
+      expect(params.get("message")).toBe("Hello there");
+    });
   });
 });

--- a/.vitepress/theme/components/HomeContact.vue
+++ b/.vitepress/theme/components/HomeContact.vue
@@ -11,14 +11,24 @@ const formSubmitting = ref(false);
 
 async function handleSubmit() {
   formStatus.value = "";
-  formSubmitting.value = true;
   formError.value = false;
+
+  const name = formName.value.trim();
+  const email = formEmail.value.trim();
+  const message = formMessage.value.trim();
+  if (!name || !email || !message) {
+    formError.value = true;
+    formStatus.value = "Please fill in all fields before sending.";
+    return;
+  }
+
+  formSubmitting.value = true;
   try {
     const body = new URLSearchParams({
       "form-name": "contact_form",
-      name: formName.value,
-      email: formEmail.value,
-      message: formMessage.value,
+      name,
+      email,
+      message,
     });
     const res = await fetch("/", {
       method: "POST",


### PR DESCRIPTION
## Problem

The home page contact form (`HomeContact.vue`) accepted empty submissions, resulting in an email arriving with a missing **name** and **message**.

The fields had the `required` HTML attribute, but the `<form>` also had `novalidate`, which disables native browser validation. Since `handleSubmit` never checked the field values either, there was nothing actually stopping an empty (or partial) form from being POSTed.

## Fix

`handleSubmit` now validates that **name**, **email**, and **message** are all non-empty (after trimming) before sending. If any are missing, submission is blocked and an inline error is shown:

> Please fill in all fields before sending.

The submitted values are now trimmed as well, so whitespace-only input no longer slips through.

## Tests

Added tests in `HomeContact.test.ts` proving the behavior:

- No network call + error message when **all** fields are empty
- No network call when **name**, **email**, or **message** individually is missing
- No network call when fields contain only whitespace
- Happy path: full form submits with the correct payload and success message
- Surrounding whitespace is trimmed from submitted values

All 158 tests pass (`vitest run`), and prettier/eslint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BNL9YK3W4i4CN3pxFSPT1

---
_Generated by [Claude Code](https://claude.ai/code/session_019BNL9YK3W4i4CN3pxFSPT1)_