### PR TITLE
Add Netlify proxy rewrite for /location-checker

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,4 @@
 https://danholloran.netlify.app/* https://danholloran.me/:splat 301!
 /blog/* /posts/:splat 301!
+/location-checker https://bert-location-checker.netlify.app/ 200
+/location-checker/* https://bert-location-checker.netlify.app/:splat 200


### PR DESCRIPTION
## Summary

Adds a Netlify proxy rewrite so that `/location-checker` on danholloran.me serves the content hosted at `https://bert-location-checker.netlify.app/`.

Because these rules use status `200` (a rewrite/proxy) rather than `301` (a redirect), the visitor's URL stays on `danholloran.me/location-checker` while Netlify transparently proxies the upstream app.

## Changes

Added two lines to `public/_redirects`:

```
/location-checker https://bert-location-checker.netlify.app/ 200
/location-checker/* https://bert-location-checker.netlify.app/:splat 200
```

- The first rule proxies the exact `/location-checker` path.
- The second proxies every subpath, forwarding the remainder via `:splat`.

## Notes

Netlify proxying to an external host requires the `200` status code; the existing rules in this file use `301!` for true redirects, which is why the new rules intentionally differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA9qEd13QaN4UmmzAqxF8W)_